### PR TITLE
Small Style Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 dist/
 plogs.egg-info/
+.python-version

--- a/src/logutils.py
+++ b/src/logutils.py
@@ -6,7 +6,6 @@
 from enum import Enum
 
 import os
-import sys
 
 class Levels(Enum):
     INFO = 1
@@ -16,38 +15,21 @@ class Levels(Enum):
     ERROR = 5
     STATUS = 6
 
+    def level(self):
+        return self.name
 
-class Colors:
-
-    _color_map = {
-        Levels.INFO: '\033[94m',
-        Levels.STATUS: '\033[1m',
-        Levels.SUCCESS: '\033[92m',
-        Levels.WARNING: '\033[93m',
-        Levels.ERROR: '\033[91m',
-        Levels.CRITICAL: '\u001b[41;1m',
-        'end': '\033[0m',
-    }
-
-    @staticmethod
-    def color(log_lvl):
-        return Colors._color_map[log_lvl]
-
-
-class LogLevel:
-
-    _level_map = {
-        Levels.INFO: 'INFO',
-        Levels.STATUS: 'STATUS',
-        Levels.SUCCESS: 'SUCCESS',
-        Levels.WARNING: 'WARNING',
-        Levels.ERROR: 'ERROR',
-        Levels.CRITICAL: 'CRITICAL',
-    }
-
-    @staticmethod
-    def level(log_lvl):
-        return LogLevel._level_map[log_lvl]
+    def color(self):
+        # TODO: fix the fact that passing in 'end' is necessary and "proper use."
+        _color_map = {
+            Levels.INFO: '\033[94m',
+            Levels.STATUS: '\033[1m',
+            Levels.SUCCESS: '\033[92m',
+            Levels.WARNING: '\033[93m',
+            Levels.ERROR: '\033[91m',
+            Levels.CRITICAL: '\u001b[41;1m',
+            'end': '\033[0m',
+        }
+        return _color_map[self]
 
 
 def check_config(pretty, show_levels, show_time, to_file, file_location, filename):
@@ -55,44 +37,26 @@ def check_config(pretty, show_levels, show_time, to_file, file_location, filenam
     # if trying to write to file, the following cases must hold true
     if to_file:
        # file_location and filename must be strings
-        try:
-            assert isinstance(file_location, str)
-            assert isinstance(filename, str)
-            assert len(file_location) > 0
-            assert len(filename) > 0
-        except AssertionError as err:
-            print('`filename` or `file_location` must be a non-empty string')
-            raise
+        if not isinstance(file_location, str) or not isinstance(filename, str):
+            raise TypeError('`filename` or `file_location` must be a non-empty string')
+        elif len(file_location) == 0 or len(filename) == 0
+            raise ValueError('`filename` or `file_location` must be a non-empty string')
 
         # file_location must exist
         if not os.path.exists(file_location):
-            try:
-                os.mkdir(file_location)
-            except Exception as err:
-                print('Permission Denied: cannot write to `file_location: ', file_location)
-                print('Must run program as root user')
-                sys.exit(0)
-        else:
-            try:
-                assert os.path.exists(file_location)
-            except AssertionError as err:
-                print('`file_location`:', file_location,' - is broken')
+            #assumes that the error will just raise
+            os.mkdir(file_location)
 
     # config variables must be type `bool`
-    try:
-        assert isinstance(pretty, bool)
-        assert isinstance(show_levels, bool)
-        assert isinstance(show_time, bool)
-        assert isinstance(to_file, bool)
-    except AssertionError as err:
-        print(
-            'One of the following config variables is not of type `bool`:\n ',
-            'pretty: ', pretty,
-            'show_levels: ', show_levels,
-            'show_time: ', show_time,
-            'to_file: ', to_file,
+    if not isinstance(pretty, bool) or not isinstance(show_levels, bool)\
+            or not isinstance(show_time, bool) or not isinstance(to_file, bool):
+        raise TypeError(
+            'One of the following config variables is not of type `bool`:\n ' +\
+            'pretty: ' + pretty + '\n' +\
+            'show_levels: ' + show_levels + '\n' +\
+            'show_time: ' + show_time + '\n' +\
+            'to_file: ' + to_file
         )
-        raise
 
     # return updated vars
     return pretty, show_levels, show_time, to_file, file_location, filename

--- a/src/logutils.py
+++ b/src/logutils.py
@@ -39,7 +39,7 @@ def check_config(pretty, show_levels, show_time, to_file, file_location, filenam
        # file_location and filename must be strings
         if not isinstance(file_location, str) or not isinstance(filename, str):
             raise TypeError('`filename` or `file_location` must be a non-empty string')
-        elif len(file_location) == 0 or len(filename) == 0
+        elif len(file_location) == 0 or len(filename) == 0:
             raise ValueError('`filename` or `file_location` must be a non-empty string')
 
         # file_location must exist

--- a/src/plogutils.py
+++ b/src/plogutils.py
@@ -79,17 +79,8 @@ class _Logger:
 
         # {{NOTE: any log variables that are added must be get appended in here}}
         if self._fstr:
-            log = self._fstr
-
-            if self._show_levels:
-                log = log.replace('{level}', self._levels(log_lvl))
-            if self._show_time:
-                log = log.replace('{time}', str(datetime.datetime.now()))
-            if self._to_file:
-                log = log.replace('{filename}', self._filename)
-
-            # always need to replace msg
-            log = log.replace('{msg}', msg)
+            log = self._fstr.format(level=self._levels(log_lvl),
+                    time=str(datetime.datetime.now()), filename=self._filename, msg=msg)
 
         # colors the logs if self_.pretty == True
         if self._pretty:

--- a/src/plogutils.py
+++ b/src/plogutils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf8 -*-
 
-from .logutils import LogLevel, Colors, Levels, check_config
+from .logutils import Levels, check_config
 
 import pprint
 import datetime
@@ -24,8 +24,8 @@ class _Logger:
 
     def __init__(self):
         # Instances of Color and Levels enum
-        self._colors = Colors.color
-        self._levels = LogLevel.level
+        self._colors = Levels.color
+        self._levels = Levels.level
 
         # Formatting variables
         self._show_levels = False

--- a/src/tableutils.py
+++ b/src/tableutils.py
@@ -12,8 +12,6 @@ class Table:
         self.construct_table()
 
     def construct_table(self):
-        key_val_msg = '{}{}{}: {}{}{}'
-
         col_names = set()
         col_padding = []
 


### PR DESCRIPTION
Just a few things that were messy, kinda fixed:
- The Enum now has the `color` and `level` functions so that an external class is not needed for either.
- The assertions are replaced with if statements and the exception raised is more representative of the issue.
  - In the case of the file IO error, I figured that the caller might as well be given a chance to handle the error.
- The `_format` method uses python's built in format so that it's less hacky and better known to users.

I left a small suggestion: `'end'` should not be treated as a color, technically (or at least doing so feels hacky).
I think the `color` method _could_ be replaced with a `colorize` method that just wraps the message in the
color needed, but this might hamper future extensibility?

I'll be back with ideas on making this more extensible!